### PR TITLE
style: format python code

### DIFF
--- a/python/emit_log.py
+++ b/python/emit_log.py
@@ -4,7 +4,8 @@ import sys
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.exchange_declare(exchange='logs', exchange_type='fanout')
@@ -12,4 +13,5 @@ channel.exchange_declare(exchange='logs', exchange_type='fanout')
 message = ' '.join(sys.argv[1:]) or 'info: Hello World!'
 channel.basic_publish(exchange='logs', routing_key='', body=message)
 print(f' [x] Sent {message}')
+
 connection.close()

--- a/python/emit_log.py
+++ b/python/emit_log.py
@@ -9,7 +9,7 @@ channel = connection.channel()
 
 channel.exchange_declare(exchange='logs', exchange_type='fanout')
 
-message = ' '.join(sys.argv[1:]) or "info: Hello World!"
+message = ' '.join(sys.argv[1:]) or 'info: Hello World!'
 channel.basic_publish(exchange='logs', routing_key='', body=message)
-print(f" [x] Sent {message}")
+print(f' [x] Sent {message}')
 connection.close()

--- a/python/emit_log_direct.py
+++ b/python/emit_log_direct.py
@@ -4,7 +4,8 @@ import sys
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.exchange_declare(exchange='direct_logs', exchange_type='direct')
@@ -12,6 +13,10 @@ channel.exchange_declare(exchange='direct_logs', exchange_type='direct')
 severity = sys.argv[1] if len(sys.argv) > 2 else 'info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(
-    exchange='direct_logs', routing_key=severity, body=message)
+    exchange='direct_logs',
+    routing_key=severity,
+    body=message,
+)
 print(f' [x] Sent {severity}:{message}')
+
 connection.close()

--- a/python/emit_log_direct.py
+++ b/python/emit_log_direct.py
@@ -13,5 +13,5 @@ severity = sys.argv[1] if len(sys.argv) > 2 else 'info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(
     exchange='direct_logs', routing_key=severity, body=message)
-print(f" [x] Sent {severity}:{message}")
+print(f' [x] Sent {severity}:{message}')
 connection.close()

--- a/python/emit_log_topic.py
+++ b/python/emit_log_topic.py
@@ -4,7 +4,8 @@ import sys
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.exchange_declare(exchange='topic_logs', exchange_type='topic')
@@ -12,6 +13,10 @@ channel.exchange_declare(exchange='topic_logs', exchange_type='topic')
 routing_key = sys.argv[1] if len(sys.argv) > 2 else 'anonymous.info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(
-    exchange='topic_logs', routing_key=routing_key, body=message)
+    exchange='topic_logs',
+    routing_key=routing_key,
+    body=message,
+)
 print(f' [x] Sent {routing_key}:{message}')
+
 connection.close()

--- a/python/emit_log_topic.py
+++ b/python/emit_log_topic.py
@@ -13,5 +13,5 @@ routing_key = sys.argv[1] if len(sys.argv) > 2 else 'anonymous.info'
 message = ' '.join(sys.argv[2:]) or 'Hello World!'
 channel.basic_publish(
     exchange='topic_logs', routing_key=routing_key, body=message)
-print(f" [x] Sent {routing_key}:{message}")
+print(f' [x] Sent {routing_key}:{message}')
 connection.close()

--- a/python/new_task.py
+++ b/python/new_task.py
@@ -4,7 +4,8 @@ import sys
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.queue_declare(queue='task_queue', durable=True)
@@ -16,6 +17,8 @@ channel.basic_publish(
     body=message,
     properties=pika.BasicProperties(
         delivery_mode=pika.DeliveryMode.Persistent,
-    ))
+    ),
+)
 print(f' [x] Sent {message}')
+
 connection.close()

--- a/python/new_task.py
+++ b/python/new_task.py
@@ -9,7 +9,7 @@ channel = connection.channel()
 
 channel.queue_declare(queue='task_queue', durable=True)
 
-message = ' '.join(sys.argv[1:]) or "Hello World!"
+message = ' '.join(sys.argv[1:]) or 'Hello World!'
 channel.basic_publish(
     exchange='',
     routing_key='task_queue',
@@ -17,5 +17,5 @@ channel.basic_publish(
     properties=pika.BasicProperties(
         delivery_mode=pika.DeliveryMode.Persistent,
     ))
-print(f" [x] Sent {message}")
+print(f' [x] Sent {message}')
 connection.close()

--- a/python/receive.py
+++ b/python/receive.py
@@ -11,7 +11,7 @@ def main():
     channel.queue_declare(queue='hello')
 
     def callback(ch, method, properties, body):
-        print(f" [x] Received {body.decode()}")
+        print(f' [x] Received {body.decode()}')
 
     channel.basic_consume(queue='hello', on_message_callback=callback, auto_ack=True)
 

--- a/python/receive.py
+++ b/python/receive.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 import os
-import pika
 import sys
+
+import pika
 
 
 def main():
-    connection = pika.BlockingConnection(pika.ConnectionParameters(host='localhost'))
+    connection = pika.BlockingConnection(
+        pika.ConnectionParameters(host='localhost'),
+    )
     channel = connection.channel()
 
     channel.queue_declare(queue='hello')
@@ -13,7 +16,11 @@ def main():
     def callback(ch, method, properties, body):
         print(f' [x] Received {body.decode()}')
 
-    channel.basic_consume(queue='hello', on_message_callback=callback, auto_ack=True)
+    channel.basic_consume(
+        queue='hello',
+        on_message_callback=callback,
+        auto_ack=True,
+    )
 
     print(' [*] Waiting for messages. To exit press CTRL+C')
     channel.start_consuming()

--- a/python/receive_logs.py
+++ b/python/receive_logs.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 import os
-import pika
 import sys
+
+import pika
 
 
 def main():
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host='localhost'))
+        pika.ConnectionParameters(host='localhost'),
+    )
     channel = connection.channel()
 
     channel.exchange_declare(exchange='logs', exchange_type='fanout')
@@ -21,7 +23,10 @@ def main():
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
     channel.basic_consume(
-        queue=queue_name, on_message_callback=callback, auto_ack=True)
+        queue=queue_name,
+        on_message_callback=callback,
+        auto_ack=True,
+    )
 
     channel.start_consuming()
 

--- a/python/receive_logs.py
+++ b/python/receive_logs.py
@@ -17,7 +17,7 @@ def main():
     channel.queue_bind(exchange='logs', queue=queue_name)
 
     def callback(ch, method, properties, body):
-        print(f" [x] {body.decode()}")
+        print(f' [x] {body.decode()}')
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
     channel.basic_consume(

--- a/python/receive_logs_direct.py
+++ b/python/receive_logs_direct.py
@@ -16,7 +16,7 @@ def main():
 
     severities = sys.argv[1:]
     if not severities:
-        sys.stderr.write("Usage: %s [info] [warning] [error]\n" % sys.argv[0])
+        sys.stderr.write('Usage: %s [info] [warning] [error]\n' % sys.argv[0])
         sys.exit(1)
 
     for severity in severities:
@@ -26,7 +26,7 @@ def main():
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
     def callback(ch, method, properties, body):
-        print(f" [x] {method.routing_key}:{body.decode()}")
+        print(f' [x] {method.routing_key}:{body.decode()}')
 
     channel.basic_consume(
         queue=queue_name, on_message_callback=callback, auto_ack=True)

--- a/python/receive_logs_direct.py
+++ b/python/receive_logs_direct.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 import os
-import pika
 import sys
+
+import pika
 
 
 def main():
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host='localhost'))
+        pika.ConnectionParameters(host='localhost'),
+    )
     channel = connection.channel()
 
     channel.exchange_declare(exchange='direct_logs', exchange_type='direct')
@@ -21,7 +23,10 @@ def main():
 
     for severity in severities:
         channel.queue_bind(
-            exchange='direct_logs', queue=queue_name, routing_key=severity)
+            exchange='direct_logs',
+            queue=queue_name,
+            routing_key=severity,
+        )
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
@@ -29,7 +34,10 @@ def main():
         print(f' [x] {method.routing_key}:{body.decode()}')
 
     channel.basic_consume(
-        queue=queue_name, on_message_callback=callback, auto_ack=True)
+        queue=queue_name,
+        on_message_callback=callback,
+        auto_ack=True,
+    )
 
     channel.start_consuming()
 

--- a/python/receive_logs_topic.py
+++ b/python/receive_logs_topic.py
@@ -16,7 +16,7 @@ def main():
 
     binding_keys = sys.argv[1:]
     if not binding_keys:
-        sys.stderr.write("Usage: %s [binding_key]...\n" % sys.argv[0])
+        sys.stderr.write('Usage: %s [binding_key]...\n' % sys.argv[0])
         sys.exit(1)
 
     for binding_key in binding_keys:
@@ -26,7 +26,7 @@ def main():
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
     def callback(ch, method, properties, body):
-        print(f" [x] {method.routing_key}:{body.decode()}")
+        print(f' [x] {method.routing_key}:{body.decode()}')
 
     channel.basic_consume(
         queue=queue_name, on_message_callback=callback, auto_ack=True)

--- a/python/receive_logs_topic.py
+++ b/python/receive_logs_topic.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 import os
-import pika
 import sys
+
+import pika
 
 
 def main():
     connection = pika.BlockingConnection(
-        pika.ConnectionParameters(host='localhost'))
+        pika.ConnectionParameters(host='localhost'),
+    )
     channel = connection.channel()
 
     channel.exchange_declare(exchange='topic_logs', exchange_type='topic')
@@ -21,7 +23,10 @@ def main():
 
     for binding_key in binding_keys:
         channel.queue_bind(
-            exchange='topic_logs', queue=queue_name, routing_key=binding_key)
+            exchange='topic_logs',
+            queue=queue_name,
+            routing_key=binding_key,
+        )
 
     print(' [*] Waiting for logs. To exit press CTRL+C')
 
@@ -29,7 +34,10 @@ def main():
         print(f' [x] {method.routing_key}:{body.decode()}')
 
     channel.basic_consume(
-        queue=queue_name, on_message_callback=callback, auto_ack=True)
+        queue=queue_name,
+        on_message_callback=callback,
+        auto_ack=True,
+    )
 
     channel.start_consuming()
 

--- a/python/rpc_client.py
+++ b/python/rpc_client.py
@@ -8,7 +8,8 @@ class FibonacciRpcClient(object):
 
     def __init__(self):
         self.connection = pika.BlockingConnection(
-            pika.ConnectionParameters(host='localhost'))
+            pika.ConnectionParameters(host='localhost'),
+        )
 
         self.channel = self.connection.channel()
 
@@ -18,7 +19,8 @@ class FibonacciRpcClient(object):
         self.channel.basic_consume(
             queue=self.callback_queue,
             on_message_callback=self.on_response,
-            auto_ack=True)
+            auto_ack=True,
+        )
 
         self.response = None
         self.corr_id = None
@@ -37,7 +39,8 @@ class FibonacciRpcClient(object):
                 reply_to=self.callback_queue,
                 correlation_id=self.corr_id,
             ),
-            body=str(n))
+            body=str(n),
+        )
         self.connection.process_data_events(time_limit=None)
         return int(self.response)
 

--- a/python/rpc_client.py
+++ b/python/rpc_client.py
@@ -44,6 +44,6 @@ class FibonacciRpcClient(object):
 
 fibonacci_rpc = FibonacciRpcClient()
 
-print(" [x] Requesting fib(30)")
+print(' [x] Requesting fib(30)')
 response = fibonacci_rpc.call(30)
-print(f" [.] Got {response}")
+print(f' [.] Got {response}')

--- a/python/rpc_server.py
+++ b/python/rpc_server.py
@@ -21,7 +21,7 @@ def fib(n):
 def on_request(ch, method, props, body):
     n = int(body)
 
-    print(f" [.] fib({n})")
+    print(f' [.] fib({n})')
     response = fib(n)
 
     ch.basic_publish(exchange='',
@@ -35,5 +35,5 @@ def on_request(ch, method, props, body):
 channel.basic_qos(prefetch_count=1)
 channel.basic_consume(queue='rpc_queue', on_message_callback=on_request)
 
-print(" [x] Awaiting RPC requests")
+print(' [x] Awaiting RPC requests')
 channel.start_consuming()

--- a/python/rpc_server.py
+++ b/python/rpc_server.py
@@ -2,8 +2,8 @@
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
-
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.queue_declare(queue='rpc_queue')
@@ -24,11 +24,12 @@ def on_request(ch, method, props, body):
     print(f' [.] fib({n})')
     response = fib(n)
 
-    ch.basic_publish(exchange='',
-                     routing_key=props.reply_to,
-                     properties=pika.BasicProperties(correlation_id= \
-                                                         props.correlation_id),
-                     body=str(response))
+    ch.basic_publish(
+        exchange='',
+        routing_key=props.reply_to,
+        properties=pika.BasicProperties(correlation_id=props.correlation_id),
+        body=str(response),
+    )
     ch.basic_ack(delivery_tag=method.delivery_tag)
 
 

--- a/python/send.py
+++ b/python/send.py
@@ -2,11 +2,13 @@
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.queue_declare(queue='hello')
 
 channel.basic_publish(exchange='', routing_key='hello', body='Hello World!')
 print(" [x] Sent 'Hello World!'")
+
 connection.close()

--- a/python/worker.py
+++ b/python/worker.py
@@ -4,7 +4,8 @@ import time
 import pika
 
 connection = pika.BlockingConnection(
-    pika.ConnectionParameters(host='localhost'))
+    pika.ConnectionParameters(host='localhost'),
+)
 channel = connection.channel()
 
 channel.queue_declare(queue='task_queue', durable=True)

--- a/python/worker.py
+++ b/python/worker.py
@@ -12,9 +12,9 @@ print(' [*] Waiting for messages. To exit press CTRL+C')
 
 
 def callback(ch, method, properties, body):
-    print(f" [x] Received {body.decode()}")
+    print(f' [x] Received {body.decode()}')
     time.sleep(body.count(b'.'))
-    print(" [x] Done")
+    print(' [x] Done')
     ch.basic_ack(delivery_tag=method.delivery_tag)
 
 


### PR DESCRIPTION
1. Replace double quotes with single quotes (where possible) for consistency
2. Format parameters into separate lines for clarity
3. Sort imports by standard